### PR TITLE
Added a reduce animation setting for player control to disable slide out

### DIFF
--- a/app/src/main/java/live/mehiz/mpvkt/preferences/PlayerPreferences.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/preferences/PlayerPreferences.kt
@@ -45,4 +45,5 @@ class PlayerPreferences(
 
   val allowGesturesInPanels = preferenceStore.getBoolean("allow_gestures_in_panels")
   val showSystemStatusBar = preferenceStore.getBoolean("show_system_status_bar")
+  val reduceMotion = preferenceStore.getBoolean("reduce_motion")
 }

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/PlayerControls.kt
@@ -169,17 +169,27 @@ fun PlayerControls(
         AnimatedVisibility(
           isBrightnessSliderShown,
           enter =
-          if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) {
-            if (swapVolumeAndBrightness) -it else it }
-            + fadeIn(playerControlsEnterAnimationSpec(),
-          )
-          else fadeIn(playerControlsEnterAnimationSpec()),
+          if (!reduceMotion) {
+            slideInHorizontally(playerControlsEnterAnimationSpec()) {
+              if (swapVolumeAndBrightness) -it else it
+            } +
+              fadeIn(
+                playerControlsEnterAnimationSpec(),
+              )
+          } else {
+            fadeIn(playerControlsEnterAnimationSpec())
+          },
           exit =
-          if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) {
-            if (swapVolumeAndBrightness) -it else it }
-            + fadeOut(playerControlsExitAnimationSpec(),
-          )
-          else fadeOut(playerControlsExitAnimationSpec()),
+          if (!reduceMotion) {
+            slideOutHorizontally(playerControlsExitAnimationSpec()) {
+              if (swapVolumeAndBrightness) -it else it
+            } +
+              fadeOut(
+                playerControlsExitAnimationSpec(),
+              )
+          } else {
+            fadeOut(playerControlsExitAnimationSpec())
+          },
           modifier = Modifier.constrainAs(brightnessSlider) {
             if (swapVolumeAndBrightness) {
               start.linkTo(parent.start, spacing.medium)
@@ -194,17 +204,27 @@ fun PlayerControls(
         AnimatedVisibility(
           isVolumeSliderShown,
           enter =
-          if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) {
-            if (swapVolumeAndBrightness) it else -it }
-            + fadeIn(playerControlsEnterAnimationSpec(),
-          )
-          else fadeIn(playerControlsEnterAnimationSpec()),
+          if (!reduceMotion) {
+            slideInHorizontally(playerControlsEnterAnimationSpec()) {
+              if (swapVolumeAndBrightness) it else -it
+            } +
+              fadeIn(
+                playerControlsEnterAnimationSpec(),
+              )
+          } else {
+            fadeIn(playerControlsEnterAnimationSpec())
+          },
           exit =
-          if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) {
-            if (swapVolumeAndBrightness) it else -it }
-            + fadeOut(playerControlsExitAnimationSpec(),
-          )
-          else fadeOut(playerControlsExitAnimationSpec()),
+          if (!reduceMotion) {
+            slideOutHorizontally(playerControlsExitAnimationSpec()) {
+              if (swapVolumeAndBrightness) it else -it
+            } +
+              fadeOut(
+                playerControlsExitAnimationSpec(),
+              )
+          } else {
+            fadeOut(playerControlsExitAnimationSpec())
+          },
           modifier = Modifier.constrainAs(volumeSlider) {
             if (swapVolumeAndBrightness) {
               end.linkTo(parent.end, spacing.medium)
@@ -313,12 +333,18 @@ fun PlayerControls(
         }
         AnimatedVisibility(
           visible = (controlsShown || seekBarShown) && !areControlsLocked,
-          enter = if (!reduceMotion) slideInVertically(playerControlsEnterAnimationSpec()) { it } +
+          enter = if (!reduceMotion) {
+            slideInVertically(playerControlsEnterAnimationSpec()) { it } +
+              fadeIn(playerControlsEnterAnimationSpec())
+          } else {
             fadeIn(playerControlsEnterAnimationSpec())
-          else fadeIn(playerControlsEnterAnimationSpec()),
-          exit = if (!reduceMotion) slideOutVertically(playerControlsExitAnimationSpec()) { it } +
+          },
+          exit = if (!reduceMotion) {
+            slideOutVertically(playerControlsExitAnimationSpec()) { it } +
+              fadeOut(playerControlsExitAnimationSpec())
+          } else {
             fadeOut(playerControlsExitAnimationSpec())
-          else fadeOut(playerControlsExitAnimationSpec()),
+          },
           modifier = Modifier.constrainAs(seekbar) {
             bottom.linkTo(parent.bottom, spacing.medium)
           },
@@ -344,12 +370,18 @@ fun PlayerControls(
         }
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
+          enter = if (!reduceMotion) {
+            slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
+              fadeIn(playerControlsEnterAnimationSpec())
+          } else {
             fadeIn(playerControlsEnterAnimationSpec())
-          else fadeIn(playerControlsEnterAnimationSpec()),
-          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
+          },
+          exit = if (!reduceMotion) {
+            slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
+              fadeOut(playerControlsExitAnimationSpec())
+          } else {
             fadeOut(playerControlsExitAnimationSpec())
-          else fadeOut(playerControlsExitAnimationSpec()),
+          },
           modifier = Modifier.constrainAs(topLeftControls) {
             top.linkTo(parent.top, spacing.medium)
             start.linkTo(parent.start)
@@ -360,12 +392,18 @@ fun PlayerControls(
         // Top right controls
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
+          enter = if (!reduceMotion) {
+            slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
+              fadeIn(playerControlsEnterAnimationSpec())
+          } else {
             fadeIn(playerControlsEnterAnimationSpec())
-          else fadeIn(playerControlsEnterAnimationSpec()),
-          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
+          },
+          exit = if (!reduceMotion) {
+            slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
+              fadeOut(playerControlsExitAnimationSpec())
+          } else {
             fadeOut(playerControlsExitAnimationSpec())
-          else fadeOut(playerControlsExitAnimationSpec()),
+          },
           modifier = Modifier.constrainAs(topRightControls) {
             top.linkTo(parent.top, spacing.medium)
             end.linkTo(parent.end)
@@ -374,12 +412,18 @@ fun PlayerControls(
         // Bottom right controls
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
+          enter = if (!reduceMotion) {
+            slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
+              fadeIn(playerControlsEnterAnimationSpec())
+          } else {
             fadeIn(playerControlsEnterAnimationSpec())
-          else fadeIn(playerControlsEnterAnimationSpec()),
-          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
+          },
+          exit = if (!reduceMotion) {
+            slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
+              fadeOut(playerControlsExitAnimationSpec())
+          } else {
             fadeOut(playerControlsExitAnimationSpec())
-          else fadeOut(playerControlsExitAnimationSpec()),
+          },
           modifier = Modifier.constrainAs(bottomRightControls) {
             bottom.linkTo(seekbar.top)
             end.linkTo(seekbar.end)
@@ -388,12 +432,18 @@ fun PlayerControls(
         // Bottom left controls
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
+          enter = if (!reduceMotion) {
+            slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
+              fadeIn(playerControlsEnterAnimationSpec())
+          } else {
             fadeIn(playerControlsEnterAnimationSpec())
-          else fadeIn(playerControlsEnterAnimationSpec()),
-          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
+          },
+          exit = if (!reduceMotion) {
+            slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
+              fadeOut(playerControlsExitAnimationSpec())
+          } else {
             fadeOut(playerControlsExitAnimationSpec())
-          else fadeOut(playerControlsExitAnimationSpec()),
+          },
           modifier = Modifier.constrainAs(bottomLeftControls) {
             bottom.linkTo(seekbar.top)
             start.linkTo(seekbar.start)

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/PlayerControls.kt
@@ -1,5 +1,8 @@
 package live.mehiz.mpvkt.ui.player.controls
 
+import android.R.attr.bottom
+import android.R.attr.end
+import android.R.attr.top
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.FiniteAnimationSpec
@@ -152,6 +155,7 @@ fun PlayerControls(
         val volume by viewModel.currentVolume.collectAsState()
         val mpvVolume by viewModel.currentMPVVolume.collectAsState()
         val swapVolumeAndBrightness by playerPreferences.swapVolumeAndBrightness.collectAsState()
+        val reduceMotion by playerPreferences.reduceMotion.collectAsState()
 
         LaunchedEffect(volume, mpvVolume, isVolumeSliderShown) {
           delay(2000)
@@ -163,16 +167,18 @@ fun PlayerControls(
         }
         AnimatedVisibility(
           isBrightnessSliderShown,
-          enter = slideInHorizontally(playerControlsEnterAnimationSpec()) {
-            if (swapVolumeAndBrightness) -it else it
-          } + fadeIn(
-            playerControlsEnterAnimationSpec(),
-          ),
-          exit = slideOutHorizontally(playerControlsExitAnimationSpec()) {
-            if (swapVolumeAndBrightness) -it else it
-          } + fadeOut(
-            playerControlsExitAnimationSpec(),
-          ),
+          enter =
+          if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) {
+            if (swapVolumeAndBrightness) -it else it }
+            + fadeIn(playerControlsEnterAnimationSpec(),
+          )
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit =
+          if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) {
+            if (swapVolumeAndBrightness) -it else it }
+            + fadeOut(playerControlsExitAnimationSpec(),
+          )
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(brightnessSlider) {
             if (swapVolumeAndBrightness) start.linkTo(parent.start, spacing.medium)
             else end.linkTo(parent.end, spacing.medium)
@@ -183,16 +189,18 @@ fun PlayerControls(
 
         AnimatedVisibility(
           isVolumeSliderShown,
-          enter = slideInHorizontally(playerControlsEnterAnimationSpec()) {
-            if (swapVolumeAndBrightness) it else -it
-          } + fadeIn(
-            playerControlsEnterAnimationSpec(),
-          ),
-          exit = slideOutHorizontally(playerControlsExitAnimationSpec()) {
-            if (swapVolumeAndBrightness) it else -it
-          } + fadeOut(
-            playerControlsExitAnimationSpec(),
-          ),
+          enter =
+          if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) {
+            if (swapVolumeAndBrightness) it else -it }
+            + fadeIn(playerControlsEnterAnimationSpec(),
+          )
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit =
+          if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) {
+            if (swapVolumeAndBrightness) it else -it }
+            + fadeOut(playerControlsExitAnimationSpec(),
+          )
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(volumeSlider) {
             if (swapVolumeAndBrightness) end.linkTo(parent.end, spacing.medium)
             else start.linkTo(parent.start, spacing.medium)
@@ -298,10 +306,12 @@ fun PlayerControls(
         }
         AnimatedVisibility(
           visible = (controlsShown || seekBarShown) && !areControlsLocked,
-          enter = slideInVertically(playerControlsEnterAnimationSpec()) { it } +
-            fadeIn(playerControlsEnterAnimationSpec()),
-          exit = slideOutVertically(playerControlsExitAnimationSpec()) { it } +
-            fadeOut(playerControlsExitAnimationSpec()),
+          enter = if (!reduceMotion) slideInVertically(playerControlsEnterAnimationSpec()) { it } +
+            fadeIn(playerControlsEnterAnimationSpec())
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit = if (!reduceMotion) slideOutVertically(playerControlsExitAnimationSpec()) { it } +
+            fadeOut(playerControlsExitAnimationSpec())
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(seekbar) {
             bottom.linkTo(parent.bottom, spacing.medium)
           },
@@ -327,10 +337,12 @@ fun PlayerControls(
         }
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
-            fadeIn(playerControlsEnterAnimationSpec()),
-          exit = slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
-            fadeOut(playerControlsExitAnimationSpec()),
+          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
+            fadeIn(playerControlsEnterAnimationSpec())
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
+            fadeOut(playerControlsExitAnimationSpec())
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(topLeftControls) {
             top.linkTo(parent.top, spacing.medium)
             start.linkTo(parent.start)
@@ -341,10 +353,12 @@ fun PlayerControls(
         // Top right controls
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
-            fadeIn(playerControlsEnterAnimationSpec()),
-          exit = slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
-            fadeOut(playerControlsExitAnimationSpec()),
+          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
+            fadeIn(playerControlsEnterAnimationSpec())
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
+            fadeOut(playerControlsExitAnimationSpec())
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(topRightControls) {
             top.linkTo(parent.top, spacing.medium)
             end.linkTo(parent.end)
@@ -353,10 +367,12 @@ fun PlayerControls(
         // Bottom right controls
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
-            fadeIn(playerControlsEnterAnimationSpec()),
-          exit = slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
-            fadeOut(playerControlsExitAnimationSpec()),
+          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { it } +
+            fadeIn(playerControlsEnterAnimationSpec())
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { it } +
+            fadeOut(playerControlsExitAnimationSpec())
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(bottomRightControls) {
             bottom.linkTo(seekbar.top)
             end.linkTo(seekbar.end)
@@ -365,10 +381,12 @@ fun PlayerControls(
         // Bottom left controls
         AnimatedVisibility(
           controlsShown && !areControlsLocked,
-          enter = slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
-            fadeIn(playerControlsEnterAnimationSpec()),
-          exit = slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
-            fadeOut(playerControlsExitAnimationSpec()),
+          enter = if (!reduceMotion) slideInHorizontally(playerControlsEnterAnimationSpec()) { -it } +
+            fadeIn(playerControlsEnterAnimationSpec())
+          else fadeIn(playerControlsEnterAnimationSpec()),
+          exit = if (!reduceMotion) slideOutHorizontally(playerControlsExitAnimationSpec()) { -it } +
+            fadeOut(playerControlsExitAnimationSpec())
+          else fadeOut(playerControlsExitAnimationSpec()),
           modifier = Modifier.constrainAs(bottomLeftControls) {
             bottom.linkTo(seekbar.top)
             start.linkTo(seekbar.start)

--- a/app/src/main/java/live/mehiz/mpvkt/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/preferences/PlayerPreferencesScreen.kt
@@ -216,7 +216,7 @@ object PlayerPreferencesScreen : Screen() {
           SwitchPreference(
             value = reduceMotion,
             onValueChange = preferences.reduceMotion::set,
-            title = { Text("Reduce player controls animation") },
+            title = { Text(stringResource(R.string.reduce_player_animation)) },
           )
         }
       }

--- a/app/src/main/java/live/mehiz/mpvkt/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/preferences/PlayerPreferencesScreen.kt
@@ -212,6 +212,12 @@ object PlayerPreferencesScreen : Screen() {
             onValueChange = preferences.showSystemStatusBar::set,
             title = { Text(stringResource(R.string.pref_player_controls_show_status_bar)) },
           )
+          val reduceMotion by preferences.reduceMotion.collectAsState()
+          SwitchPreference(
+            value = reduceMotion,
+            onValueChange = preferences.reduceMotion::set,
+            title = { Text("Reduce player controls animation") },
+          )
         }
       }
     }

--- a/app/src/main/java/live/mehiz/mpvkt/ui/preferences/PlayerPreferencesScreen.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/preferences/PlayerPreferencesScreen.kt
@@ -217,6 +217,7 @@ object PlayerPreferencesScreen : Screen() {
             value = reduceMotion,
             onValueChange = preferences.reduceMotion::set,
             title = { Text(stringResource(R.string.reduce_player_animation)) },
+          )
           val playerTimeToDisappear by preferences.playerTimeToDisappear.collectAsState()
           ListPreference(
             value = playerTimeToDisappear,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,6 +209,7 @@
 
     <string name="github_repo_url" translatable="false">https://github.com/abdallahmehiz/mpvKt</string>
     <string name="swap_the_volume_and_brightness_slider">Swap volume and brightness slider</string>
+    <string name="reduce_player_animation">Reduce player animation</string>
 
     <plurals name="plural_items">
         <item quantity="one">%1$d item</item>


### PR DESCRIPTION
Added a setting item for reducing player control animation
When enabled, the slide out is disabled, only the fade is kept
![Screenshot_20241013_163920_mpvKt](https://github.com/user-attachments/assets/8d855a34-0a7a-47f6-96ee-3ddac4f98e9d)
