### PR TITLE
Update dynamic color string

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="pref_appearance_darkmode_light">Light</string>
     <string name="pref_appearance_darkmode_dark">Dark</string>
     <string name="pref_appearance_material_you_title">Material You</string>
-    <string name="pref_appearance_material_you_summary">Enable Material You dynamic colors</string>
+    <string name="pref_appearance_material_you_summary">Enable dynamic colors</string>
     <string name="pref_appearance_material_you_summary_disabled">Only available for Android 12 and newer.</string>
 
     <string name="pref_player">Player</string>


### PR DESCRIPTION
Shortens the dynamic color string from "Enable Material You dynamic colors" to "Enable dynamic colors". The reasoning for this is:
1. It is redundant to mention Material You twice since it shows right above the short description
2. Shorter strings are better for localizing into more lengthy languages