### PR TITLE
Improve Intent behavior of PlayerActivity

### DIFF
--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/PlayerActivity.kt
@@ -834,7 +834,7 @@ class PlayerActivity : AppCompatActivity() {
 
   companion object {
     // action of result intent
-    private const val RESULT_INTENT = "live.mehiz.mpvKt.PlayerActivity.result"
+    private const val RESULT_INTENT = "live.mehiz.mpvkt.ui.player.PlayerActivity.result"
   }
 }
 

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/PlayerActivity.kt
@@ -834,7 +834,7 @@ class PlayerActivity : AppCompatActivity() {
 
   companion object {
     // action of result intent
-    private const val RESULT_INTENT = "live.mehiz.mpvKt.PlayerActivity"
+    private const val RESULT_INTENT = "live.mehiz.mpvKt.PlayerActivity.result"
   }
 }
 


### PR DESCRIPTION
I am trying to set mpvKt as external player of Jellyfin, and found some problems:

1. playback tracking:
    1. mptKv failed to handle the "position" in the intent extras(reason: set player.timePos too early, the MPV is not loaded, and reports Property Unavailable Errors)
    2. Jellyfin failed to handle the result "position" in the intent extras(reason: jellyfin need to read the intent action and do some ad-hoc works)
2. external subtitles with movie: mpvKt didn't load the external subtitles

So this PR is trying to solve those problems:
+ Delay the `setIntentExtras(..)` function, and I check the mpv-android implement, it uses the `onloadCommands`(https://github.com/mpv-android/mpv-android/blob/5dca6eb229055a99b0cec5ddd67fc68c78295150/app/src/main/java/is/xyz/mpv/MPVActivity.kt#L272) to delay the timing, so I delay the `setIntentExtras(..)` function call after receiving MPV_EVENT_FILE_LOADED event.
+  Add the `action` into the result intent
+ load external subtitles if intent extras provides related fields like mpv-android and MX player(ref: http://mpv-android.github.io/mpv-android/intent.html)

In the PR, I tests with jellyfin-android with a new PR(https://github.com/jellyfin/jellyfin-android/pull/1531), it works perfect now.

related Issue: https://github.com/jellyfin/jellyfin-android/issues/1481