### PR TITLE
Allow multiple custom buttons to be displayed in the navigation menu

### DIFF
--- a/app/src/main/java/live/mehiz/mpvkt/database/entities/CustomButtonEntity.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/database/entities/CustomButtonEntity.kt
@@ -10,5 +10,7 @@ data class CustomButtonEntity(
   val title: String,
   val content: String,
   val longPressContent: String,
+  val showInPlayer: Boolean,
+  val showInMoreSheet: Boolean,
   val index: Int,
 )

--- a/app/src/main/java/live/mehiz/mpvkt/presentation/custombuttons/components/CustomButtonDialogs.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/presentation/custombuttons/components/CustomButtonDialogs.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -15,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.FocusRequester
@@ -25,17 +28,20 @@ import kotlinx.coroutines.delay
 import live.mehiz.mpvkt.R
 import live.mehiz.mpvkt.database.entities.CustomButtonEntity
 import live.mehiz.mpvkt.ui.theme.spacing
+import me.zhanghai.compose.preference.SwitchPreference
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun CustomButtonAddDialog(
   onDismissRequest: () -> Unit,
-  onAdd: (String, String, String) -> Unit,
+  onAdd: (String, String, String, Boolean, Boolean) -> Unit,
   buttonNames: ImmutableList<String>,
 ) {
   var title by remember { mutableStateOf("") }
   var content by remember { mutableStateOf("") }
   var longPressContent by remember { mutableStateOf("") }
+  var showInPlayer by remember { mutableStateOf(true) }
+  var showInMoreSheet by remember { mutableStateOf(true) }
 
   val focusRequester = remember { FocusRequester() }
   val titleAlreadyExists = remember(title) { buttonNames.contains(title) }
@@ -46,7 +52,7 @@ fun CustomButtonAddDialog(
       TextButton(
         enabled = title.isNotEmpty() && content.isNotEmpty() && !titleAlreadyExists,
         onClick = {
-          onAdd(title, content, longPressContent)
+          onAdd(title, content, longPressContent, showInPlayer, showInMoreSheet)
           onDismissRequest()
         }
       ) {
@@ -108,6 +114,34 @@ fun CustomButtonAddDialog(
           },
           minLines = 3,
         )
+
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(
+            text = stringResource(id = R.string.pref_custom_button_show_in_player),
+            modifier = Modifier.weight(1f)
+          )
+          Switch(
+            checked = showInPlayer,
+            onCheckedChange = { showInPlayer = it }
+          )
+        }
+
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(
+            text = stringResource(id = R.string.pref_custom_button_show_in_more_sheet),
+            modifier = Modifier.weight(1f)
+          )
+          Switch(
+            checked = showInMoreSheet,
+            onCheckedChange = { showInMoreSheet = it }
+          )
+        }
       }
     }
   )
@@ -153,13 +187,15 @@ fun CustomButtonDeleteDialog(
 @Composable
 fun CustomButtonEditDialog(
   onDismissRequest: () -> Unit,
-  onEdit: (String, String, String) -> Unit,
+  onEdit: (String, String, String, Boolean, Boolean) -> Unit,
   buttonNames: ImmutableList<String>,
   initialState: CustomButtonEntity,
 ) {
   var title by remember { mutableStateOf(initialState.title) }
   var content by remember { mutableStateOf(initialState.content) }
   var longPressContent by remember { mutableStateOf(initialState.longPressContent) }
+  var showInPlayer by remember { mutableStateOf(initialState.showInPlayer) }
+  var showInMoreSheet by remember { mutableStateOf(initialState.showInMoreSheet) }
 
   val focusRequester = remember { FocusRequester() }
   val titleAlreadyExists = remember(title) { buttonNames.contains(title) }
@@ -170,7 +206,7 @@ fun CustomButtonEditDialog(
       TextButton(
         enabled = title.isNotEmpty() && content.isNotEmpty() && !titleAlreadyExists,
         onClick = {
-          onEdit(title, content, longPressContent)
+          onEdit(title, content, longPressContent, showInPlayer, showInMoreSheet)
           onDismissRequest()
         }
       ) {
@@ -242,6 +278,34 @@ fun CustomButtonEditDialog(
           minLines = 3,
           maxLines = 6,
         )
+
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(
+            text = stringResource(id = R.string.pref_custom_button_show_in_player),
+            modifier = Modifier.weight(1f)
+          )
+          Switch(
+            checked = showInPlayer,
+            onCheckedChange = { showInPlayer = it }
+          )
+        }
+
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(
+            text = stringResource(id = R.string.pref_custom_button_show_in_more_sheet),
+            modifier = Modifier.weight(1f)
+          )
+          Switch(
+            checked = showInMoreSheet,
+            onCheckedChange = { showInMoreSheet = it }
+          )
+        }
       }
     }
   )

--- a/app/src/main/java/live/mehiz/mpvkt/ui/custombuttons/CustomButtonsScreen.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/custombuttons/CustomButtonsScreen.kt
@@ -56,9 +56,9 @@ object CustomButtonsScreen : Screen() {
         val button = (dialog as CustomButtonDialog.Edit).customButton
         CustomButtonEditDialog(
           onDismissRequest = viewModel::dismissDialog,
-          onEdit = { title, content, longPressContent ->
+          onEdit = { title, content, longPressContent, showInPlayer, showInMoreSheet ->
             viewModel.editButton(
-              button.copy(title = title, content = content, longPressContent = longPressContent)
+              button.copy(title = title, content = content, longPressContent = longPressContent, showInPlayer = showInPlayer, showInMoreSheet = showInMoreSheet)
             )
           },
           buttonNames = customButtons.filter { it.title != button.title }

--- a/app/src/main/java/live/mehiz/mpvkt/ui/custombuttons/CustomButtonsScreenViewModel.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/custombuttons/CustomButtonsScreenViewModel.kt
@@ -28,13 +28,15 @@ class CustomButtonsScreenViewModel(
       initialValue = emptyList(),
     )
 
-  fun addCustomButton(title: String, content: String, longPressContent: String) {
+  fun addCustomButton(title: String, content: String, longPressContent: String, showInPlayer: Boolean, showInMoreSheet: Boolean) {
     viewModelScope.launch(Dispatchers.IO) {
       customButtonsRepository.upsert(
         CustomButtonEntity(
           title = title,
           content = content,
           longPressContent = longPressContent,
+          showInPlayer = showInPlayer,
+          showInMoreSheet = showInMoreSheet,
           index = customButtons.value.size,
         )
       )

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/BottomCenterPlayerControls.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/BottomCenterPlayerControls.kt
@@ -1,0 +1,73 @@
+package live.mehiz.mpvkt.ui.player.controls
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import live.mehiz.mpvkt.database.entities.CustomButtonEntity
+import live.mehiz.mpvkt.ui.player.execute
+import live.mehiz.mpvkt.ui.player.executeLongClick
+import androidx.compose.foundation.combinedClickable
+import live.mehiz.mpvkt.ui.theme.spacing
+import androidx.compose.runtime.remember
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.layout.PaddingValues
+
+@OptIn(ExperimentalFoundationApi::class)
+@SuppressLint("NewApi")
+@Composable
+fun BottomCenterPlayerControls(
+    customButtons: List<CustomButtonEntity>,
+    modifier: Modifier = Modifier
+) {
+    val scrollState = rememberScrollState()
+
+    Row(
+        modifier = modifier
+            .horizontalScroll(scrollState)
+            .fillMaxWidth()
+    ) {
+        customButtons.forEach { customButton ->
+            Box(
+                modifier = Modifier
+                    .padding(end = MaterialTheme.spacing.smaller)
+                    .widthIn(min = 5.dp)
+            ) {
+                Button(onClick = {},
+                    colors = ButtonDefaults.buttonColors(
+                      containerColor = Color.Transparent
+                    ),
+                    contentPadding = PaddingValues(horizontal = 0.dp)
+                ) {
+                    Text(
+                        text = customButton.title,
+                        color = Color.White,
+                        maxLines = 1)
+                }
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .combinedClickable(
+                            onClick = customButton::execute,
+                            onLongClick = customButton::executeLongClick,
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/BottomLeftPlayerControls.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/BottomLeftPlayerControls.kt
@@ -32,7 +32,6 @@ fun BottomLeftPlayerControls(
 ) {
   val playerPreferences = koinInject<PlayerPreferences>()
   Row(
-    modifier = modifier.fillMaxWidth(),
     verticalAlignment = Alignment.CenterVertically,
   ) {
     ControlsButton(

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/BottomRightPlayerControls.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/BottomRightPlayerControls.kt
@@ -26,34 +26,12 @@ import live.mehiz.mpvkt.ui.theme.spacing
 @SuppressLint("NewApi")
 @Composable
 fun BottomRightPlayerControls(
-  customButton: CustomButtonEntity?,
-  customButtonTitle: String,
   isPipAvailable: Boolean,
   onAspectClick: () -> Unit,
   onPipClick: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Row(modifier) {
-    if (customButton != null) {
-      Box(
-        modifier = Modifier.padding(end = MaterialTheme.spacing.smaller),
-      ) {
-        Button(onClick = {}) {
-          Text(text = customButtonTitle)
-        }
-        Box(
-          modifier = Modifier
-            .matchParentSize()
-            .combinedClickable(
-              onClick = customButton::execute,
-              onLongClick = customButton::executeLongClick,
-              interactionSource = remember { MutableInteractionSource() },
-              indication = null,
-            ),
-        )
-      }
-    }
-
     if (isPipAvailable) {
       ControlsButton(
         Icons.Default.PictureInPictureAlt,

--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/controls/PlayerControls.kt
@@ -139,7 +139,7 @@ fun PlayerControls(
   val primaryCustomButtonId by playerPreferences.primaryCustomButtonId.collectAsState()
   val customButtonsList by remember {
     derivedStateOf {
-      customButtons.getButtons()
+      customButtons.getButtons().filter { it.showInPlayer }
     }
   }
   LaunchedEffect(
@@ -610,7 +610,7 @@ fun PlayerControls(
       onSpeedChange = { MPVLib.setPropertyDouble("speed", it.toFixed(2).toDouble()) },
       sleepTimerTimeRemaining = sleepTimerTimeRemaining,
       onStartSleepTimer = viewModel::startTimer,
-      buttons = customButtons.getButtons().toImmutableList(),
+      buttons = customButtons.getButtons().filter { it.showInMoreSheet }.toImmutableList(),
       onOpenPanel = onOpenPanel,
       onDismissRequest = { onOpenSheet(Sheets.None) },
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,8 @@
     <string name="pref_custom_button_action_add_optional">(optional)</string>
     <string name="pref_custom_button_action_add_content_text">Lua code</string>
     <string name="pref_custom_button_action_add_long_press_text">Lua code (on long press)</string>
+    <string name="pref_custom_button_show_in_player">Show in Player</string>
+    <string name="pref_custom_button_show_in_more_sheet">Show in more sheet</string>
     <string name="pref_custom_button_add_button">Add custom button</string>
     <string name="pref_custom_button_empty">You have no custom buttons. Tap the plus button to add custom buttons.</string>
     <string name="pref_custom_button_edit_button">Edit button</string>


### PR DESCRIPTION
Since #189 has not received a response, I tried to ask AI to modify some codes of `live.mehiz.mpvkt.ui.player.controls` to realize the display of multiple custom buttons in the navigation menu. The general plan is as follows:

1. Remove the part related to **displaying primaryCustomButton** in `BottomRightPlayerControls`
2. Create a new `BottomCenterPlayerControls` to create a slidable horizontal area in the middle of the bottom of the navigation menu to display custom buttons
3. Adjust other control bars to coordinate with it.

After the modification, the compilation test passed, and the function is basically available, but there are still some problems to be solved:

1. The **primaryCustomButton** function loses its meaning
2. In the settings, there could be options to switch the display of custom buttons in the navigation menu and more menus, as well as options for controlling how many buttons are displayed.