### PR TITLE
picking video file: remove scoped storage api

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,7 @@ dependencies {
   implementation(libs.kotlinx.immutable.collections)
   implementation(libs.truetype.parser)
   implementation(libs.fsaf)
+  implementation(libs.storage.util)
 }
 
 detekt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        android:minSdkVersion="30"
+        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
 
     <application
         android:name=".App"
@@ -10,6 +15,7 @@
         android:appCategory="video"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+        android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/live/mehiz/mpvkt/ui/utils/FilesComparator.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/utils/FilesComparator.kt
@@ -1,19 +1,16 @@
 package live.mehiz.mpvkt.ui.utils
 
-import com.github.k1rakishou.fsaf.FileManager
-import com.github.k1rakishou.fsaf.file.AbstractFile
+import java.io.File
 
 /**
  * Sorts files/directories alphabetically while giving directories priority
  * credit goes to mpv-android
  */
-class FilesComparator(
-  private val fileManager: FileManager
-) : Comparator<AbstractFile> {
-  override fun compare(o1: AbstractFile?, o2: AbstractFile?): Int {
-    val iso1ADirectory = fileManager.isDirectory(o1!!)
-    val iso2ADirectory = fileManager.isDirectory(o2!!)
+class FilesComparator : Comparator<File> {
+  override fun compare(o1: File?, o2: File?): Int {
+    val iso1ADirectory = o1!!.isDirectory
+    val iso2ADirectory = o2!!.isDirectory
     if (iso1ADirectory != iso2ADirectory) return if (iso2ADirectory) 1 else -1
-    return fileManager.getName(o1).compareTo(fileManager.getName(o2), ignoreCase = true)
+    return o1.name.compareTo(o2.name, ignoreCase = true)
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ kotlinx-immutable-collections = { module = "org.jetbrains.kotlinx:kotlinx-collec
 
 truetype-parser = { module = "io.github.yubyf:truetypeparser-light", version = "2.1.4" }
 fsaf = { module = "com.github.K1rakishou:Fuck-Storage-Access-Framework", version = "1.1.3" }
+storage-util = { module = "com.github.hendrawd:StorageUtil", version = "1.1.0" }
 
 about-libs-core = { module = "com.mikepenz:aboutlibraries-core", version.ref = "about-libs" }
 about-libs-ui-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "about-libs" }


### PR DESCRIPTION
Not sure, if this is the direction this project wants to go, but I thought I’d give it a try. I added the permission to manage the entire storage, like VLC does: https://github.com/videolan/vlc-android/blob/2e6e0bd6a6667af607824ffbd5f11b746026f8a9/application/vlc-android/AndroidManifest.xml#L13. The logic is based on https://stackoverflow.com/a/78813970. Now we can select a video file without granting permissions each time. The problem of granting permissions was also described in #28:

> Agree with this request, this app would be perfect if I don't need to grant file access to MpvKT everytime when I choose FilePicker (which requires users to click at least twice)

For now, this will probably take more clicks than before as one has to select the specific directory, but this can be alleviated in the future by adding options to open the last directory or bookmark directories.