### PR TITLE
Automatically load external subtitles when using file picker

### DIFF
--- a/app/src/main/java/live/mehiz/mpvkt/preferences/SubtitlesPreferences.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/preferences/SubtitlesPreferences.kt
@@ -13,6 +13,7 @@ import live.mehiz.mpvkt.preferences.preference.getEnum
 import live.mehiz.mpvkt.ui.player.controls.components.panels.SubtitlesBorderStyle
 
 class SubtitlesPreferences(preferenceStore: PreferenceStore) {
+  val autoLoadExternal = preferenceStore.getBoolean("sub_autoload", true)
   val preferredLanguages = preferenceStore.getString("sub_preferred_languages")
 
   val fontsFolder = preferenceStore.getString("sub_fonts_folder")

--- a/app/src/main/java/live/mehiz/mpvkt/ui/preferences/SubtitlesPreferencesScreen.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/preferences/SubtitlesPreferencesScreen.kt
@@ -31,6 +31,7 @@ import live.mehiz.mpvkt.preferences.preference.collectAsState
 import live.mehiz.mpvkt.presentation.Screen
 import live.mehiz.mpvkt.ui.utils.LocalBackStack
 import me.zhanghai.compose.preference.ProvidePreferenceLocals
+import me.zhanghai.compose.preference.SwitchPreference
 import me.zhanghai.compose.preference.TextFieldPreference
 import me.zhanghai.compose.preference.TwoTargetIconButtonPreference
 import org.koin.compose.koinInject
@@ -103,6 +104,17 @@ object SubtitlesPreferencesScreen : Screen {
             iconButtonIcon = { Icon(Icons.Default.Clear, null) },
             onIconButtonClick = { preferences.fontsFolder.delete() },
             iconButtonEnabled = fontsFolder.isNotBlank()
+          )
+          val autoloadExternal by preferences.autoLoadExternal.collectAsState()
+          SwitchPreference(
+            value = autoloadExternal,
+            onValueChange = { preferences.autoLoadExternal.set(it) },
+            title = { Text(text = stringResource(id = R.string.pref_subtitles_autoload_title)) },
+            summary = {
+              Text(
+                text = stringResource(id = R.string.pref_subtitles_autoload_summary),
+              )
+            },
           )
         }
       }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -70,6 +70,8 @@
     <string name="pref_preferred_languages">首选语言</string>
     <string name="pref_subtitles_fonts_dir">字体目录</string>
     <string name="pref_subtitles_preferred_language">在具有多个字幕的视频中，默认选择的字幕语言。支持两位或三位字母的语言代码。多个值可以用逗号分隔。</string>
+    <string name="pref_subtitles_autoload_title">自动加载字幕</string>
+    <string name="pref_subtitles_autoload_summary">自动加载同名外部字幕。当有多个文件时，默认启用第一个。（仅在使用文件选择器时有效）</string>
     <string name="pref_audio">音频</string>
     <string name="pref_audio_summary">首选语言，声道，音高修正</string>
     <string name="pref_audio_pitch_correction_title">启用自动音高修正</string>
@@ -212,5 +214,5 @@
     <string name="show_splash_ovals_on_double_tap_to_seek">双击跳转时显示涟漪效果</string>
     <string name="show_icon_on_double_tap_to_seek">显示跳转时间</string>
     <string name="show_time_on_double_tap_to_seek">显示跳转图标</string>
-    
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,8 @@
     <string name="pref_preferred_languages">Preferred languages</string>
     <string name="pref_subtitles_fonts_dir">Fonts directory</string>
     <string name="pref_subtitles_preferred_language">Subtitle language(s) to be selected by default on a video with multiple subtitles, Two- or three-letter languages codes work. Multiple values can be delimited by comma.</string>
+    <string name="pref_subtitles_autoload_title">Automatically load subtitles</string>
+    <string name="pref_subtitles_autoload_summary">Automatically load external subtitles with the same name. When there are multiple files, the first one is enabled by default. (Only valid when using the file picker)</string>
 
     <string name="pref_audio">Audio</string>
     <string name="pref_audio_summary">Preferred languages, audio channels, pitch correction</string>


### PR DESCRIPTION
Support loading external subtitle files when opening a folder and playing video files using the file picker.

The external subtitle file must be in the same directory and have the same filename prefix.

This feature is enabled by default and can be turned off in `Settings - Subtitles` .