### PR TITLE
alleviate mediaSession not inited error

### DIFF
--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/MediaPlaybackService.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/MediaPlaybackService.kt
@@ -121,6 +121,8 @@ class MediaPlaybackService : MediaBrowserServiceCompat(), MPVLib.EventObserver {
   override fun onCreate() {
     super.onCreate()
 
+    setupMediaSession()
+
     audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
     MPVLib.addObserver(this)
     mapOf(
@@ -133,7 +135,6 @@ class MediaPlaybackService : MediaBrowserServiceCompat(), MPVLib.EventObserver {
       MPVLib.observeProperty(it.key, it.value)
     }
 
-    setupMediaSession()
     setupAudioFocus()
     createNotificationChannel()
   }


### PR DESCRIPTION
call setupMediaSession() prior to audioManager assignment so mediaSession is assigned/inited before mpvlib property change events are handled

fixes https://github.com/abdallahmehiz/mpvKt/issues/286